### PR TITLE
build: soong: use jemalloc by default and allow opt-in to scudo (2/4)

### DIFF
--- a/android/config.go
+++ b/android/config.go
@@ -1137,7 +1137,7 @@ func (c *config) EnableCFI() bool {
 }
 
 func (c *config) DisableScudo() bool {
-	return Bool(c.productVariables.DisableScudo)
+	return !Bool(c.productVariables.Malloc_use_scudo) && !Bool(c.productVariables.Malloc_use_scudo_32_bit)
 }
 
 func (c *config) Android64() bool {

--- a/android/variable.go
+++ b/android/variable.go
@@ -69,6 +69,15 @@ type variableProperties struct {
 			Enabled *bool `android:"arch_variant"`
 		} `android:"arch_variant"`
 
+		Malloc_use_scudo struct {
+			Cflags              []string `android:"arch_variant"`
+			Shared_libs         []string `android:"arch_variant"`
+			Whole_static_libs   []string `android:"arch_variant"`
+			Exclude_static_libs []string `android:"arch_variant"`
+			Srcs                []string `android:"arch_variant"`
+			Header_libs         []string `android:"arch_variant"`
+		} `android:"arch_variant"`
+
 		Malloc_not_svelte struct {
 			Cflags              []string `android:"arch_variant"`
 			Shared_libs         []string `android:"arch_variant"`
@@ -79,7 +88,7 @@ type variableProperties struct {
 			Header_libs         []string `android:"arch_variant"`
 		} `android:"arch_variant"`
 
-		Malloc_not_svelte_libc32 struct {
+		Malloc_use_scudo_32_bit struct {
 			Cflags              []string `android:"arch_variant"`
 			Shared_libs         []string `android:"arch_variant"`
 			Whole_static_libs   []string `android:"arch_variant"`
@@ -285,8 +294,9 @@ type ProductVariables struct {
 	Unbundled_build_image        *bool    `json:",omitempty"`
 	Always_use_prebuilt_sdks     *bool    `json:",omitempty"`
 	Skip_boot_jars_check         *bool    `json:",omitempty"`
+	Malloc_use_scudo             *bool    `json:",omitempty"`
+	Malloc_use_scudo_32_bit     *bool    `json:",omitempty"`
 	Malloc_not_svelte            *bool    `json:",omitempty"`
-	Malloc_not_svelte_libc32     *bool    `json:",omitempty"`
 	Malloc_zero_contents         *bool    `json:",omitempty"`
 	Malloc_pattern_fill_contents *bool    `json:",omitempty"`
 	Safestack                    *bool    `json:",omitempty"`
@@ -319,8 +329,6 @@ type ProductVariables struct {
 	EnableCFI       *bool    `json:",omitempty"`
 	CFIExcludePaths []string `json:",omitempty"`
 	CFIIncludePaths []string `json:",omitempty"`
-
-	DisableScudo *bool `json:",omitempty"`
 
 	MemtagHeapExcludePaths      []string `json:",omitempty"`
 	MemtagHeapAsyncIncludePaths []string `json:",omitempty"`
@@ -616,8 +624,9 @@ func (v *ProductVariables) SetDefaultConfig() {
 		AAPTCharacteristics: stringPtr("nosdcard"),
 		AAPTPrebuiltDPI:     []string{"xhdpi", "xxhdpi"},
 
+        Malloc_use_scudo:             boolPtr(false),
 		Malloc_not_svelte:            boolPtr(true),
-		Malloc_not_svelte_libc32:     boolPtr(true),
+		Malloc_use_scudo_32_bit:     boolPtr(false),
 		Malloc_zero_contents:         boolPtr(true),
 		Malloc_pattern_fill_contents: boolPtr(false),
 		Safestack:                    boolPtr(false),


### PR DESCRIPTION
Also, clean up broken DisableScudo/PRODUCT_DISABLE_SCUDO.

After these changes, malloc_not_svelte is only used to override cflags in external/jemalloc_new. Change accordingly.

Detailed reason for switching to jemalloc by default is written in the bionic commit.

[minaripenguin: Allow co-existing with 32 bit libc scudo]

Change-Id: Id5afcf064a5db6011676dc7141c71fd5bb0007cb